### PR TITLE
chore(): switch from @cycle/core to @cycle/rx-run for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "rx": "global:Rx"
   },
   "devDependencies": {
-    "@cycle/core": "^6.0.0",
+    "@cycle/rx-run": "^7.0.0-rc1",
     "assert": "^1.3.0",
     "babel-cli": "^6.4.5",
     "babel-core": "^6.4.5",

--- a/test/browser/dom-driver.js
+++ b/test/browser/dom-driver.js
@@ -1,7 +1,7 @@
 'use strict';
 /* global describe, it */
 let assert = require('assert');
-let Cycle = require('@cycle/core');
+let Cycle = require('@cycle/rx-run').default;
 let CycleDOM = require('../../src');
 let Fixture89 = require('./fixtures/issue-89');
 let Rx = require('rx');
@@ -90,9 +90,9 @@ describe('DOM Driver', function () {
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget(), {onError: errorCallback})
-    });
+    }).run();
   });
 
   it('should have isolateSource() and isolateSink() in source', function (done) {
@@ -102,13 +102,14 @@ describe('DOM Driver', function () {
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
 
     assert.strictEqual(typeof sources.DOM.isolateSource, 'function');
     assert.strictEqual(typeof sources.DOM.isolateSink, 'function');
-    sources.dispose();
+    const dispose = run();
+    dispose();
     done();
   });
 
@@ -124,9 +125,11 @@ describe('DOM Driver', function () {
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
+
+    const dispose = run();
 
     sources.DOM.select(':root').observable.skip(1).subscribe(function (root) {
       const selectEl = root.querySelector('.target');
@@ -135,8 +138,7 @@ describe('DOM Driver', function () {
       assert.strictEqual(selectEl.tagName, 'H3');
       assert.notStrictEqual(selectEl.textContent, '3');
       if (selectEl.textContent === '2') {
-        sources.dispose();
-        sinks.dispose();
+        dispose();
         setTimeout(() => {
           done();
         }, 100);

--- a/test/browser/events.js
+++ b/test/browser/events.js
@@ -1,7 +1,7 @@
 'use strict';
 /* global describe, it, beforeEach */
 let assert = require('assert');
-let Cycle = require('@cycle/core');
+let Cycle = require('@cycle/rx-run').default;
 let CycleDOM = require('../../src');
 let Rx = require('rx');
 let {svg, div, input, p, span, h2, h3, h4, form, select, option, makeDOMDriver} = CycleDOM;
@@ -24,14 +24,16 @@ describe('DOMSource.events()', function () {
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
+
+    const dispose = run();
 
     sources.DOM.select('.myelementclass').events('click').subscribe(ev => {
       assert.strictEqual(ev.type, 'click');
       assert.strictEqual(ev.target.textContent, 'Foobar');
-      sources.dispose();
+      dispose();
       done();
     });
     // Make assertions
@@ -53,15 +55,16 @@ describe('DOMSource.events()', function () {
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget('parent-001'))
     });
 
+    const dispose = run();
     // Make assertions
     sources.DOM.select('#parent-001').events('click').subscribe(ev => {
       assert.strictEqual(ev.type, 'click');
       assert.strictEqual(ev.target.textContent, 'Foobar');
-      sources.dispose();
+      dispose();
       done();
     });
 
@@ -83,15 +86,17 @@ describe('DOMSource.events()', function () {
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget('parent-002'))
     });
+
+    const dispose = run();
 
     // Make assertions
     sources.DOM.select('#myElementId').events('click').subscribe(ev => {
       assert.strictEqual(ev.type, 'click');
       assert.strictEqual(ev.target.textContent, 'Foobar');
-      sources.dispose();
+      dispose();
       done();
     });
 
@@ -116,15 +121,17 @@ describe('DOMSource.events()', function () {
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
+
+    const dispose = run();
 
     // Make assertions
     sources.DOM.events('click').subscribe(ev => {
       assert.strictEqual(ev.type, 'click');
       assert.strictEqual(ev.target.textContent, 'Foobar');
-      sources.dispose();
+      dispose();
       done();
     });
 
@@ -153,15 +160,17 @@ describe('DOMSource.events()', function () {
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
+
+    const dispose = run();
 
     // Make assertions
     sources.DOM.select('.foo').select('.bar').events('click').subscribe(ev => {
       assert.strictEqual(ev.type, 'click');
       assert.strictEqual(ev.target.textContent, 'Correct');
-      sources.dispose();
+      dispose();
       done();
     });
 
@@ -192,9 +201,11 @@ describe('DOMSource.events()', function () {
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
+
+    const dispose = run();
 
     // Make assertions
     sources.DOM.select('.clickable').events('click').elementAt(0)
@@ -207,7 +218,7 @@ describe('DOMSource.events()', function () {
       .subscribe(ev => {
         assert.strictEqual(ev.type, 'click');
         assert.strictEqual(ev.target.textContent, 'Second');
-        sources.dispose();
+        dispose();
         done();
       });
 
@@ -237,15 +248,17 @@ describe('DOMSource.events()', function () {
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget('parent-002'))
     });
+
+    const dispose = run();
 
     // Make assertions
     sources.DOM.select('.blosh').events('click').subscribe(ev => {
       assert.strictEqual(ev.type, 'click');
       assert.strictEqual(ev.target.textContent, 'Blosh');
-      sources.dispose();
+      dispose();
       done();
     });
 
@@ -273,9 +286,11 @@ describe('DOMSource.events()', function () {
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
+
+    const dispose = run();
 
     sources.DOM.select('.parent').events('click').subscribe(ev => {
       assert.strictEqual(ev.type, 'click');
@@ -287,7 +302,7 @@ describe('DOMSource.events()', function () {
       const ownerTargetIsParentH2 =
         ev.ownerTarget.tagName === 'H2' && ev.ownerTarget.className === 'parent';
       assert.strictEqual(currentTargetIsParentH2 || ownerTargetIsParentH2, true);
-      sources.dispose();
+      dispose();
       done();
     });
     // Make assertions
@@ -314,9 +329,11 @@ describe('DOMSource.events()', function () {
       }
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
+
+    const dispose = run();
 
     sources.DOM.select('.parent').events('reset').subscribe(ev => {
       assert.strictEqual(ev.type, 'reset');
@@ -353,9 +370,11 @@ describe('DOMSource.events()', function () {
       el.dispatchEvent(ev)
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
+
+    const dispose = run();
 
     sources.DOM.select('.clickable').events('click', {useCapture: true})
       .subscribe(ev => {
@@ -390,9 +409,11 @@ describe('DOMSource.events()', function () {
       }
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
+
+    const dispose = run();
 
     sources.DOM.select('.correct').events('blur', {useCapture: true})
       .subscribe(ev => {
@@ -430,9 +451,11 @@ describe('DOMSource.events()', function () {
       }
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
+
+    const dispose = run();
 
     sources.DOM.select('.correct').events('blur')
       .subscribe(ev => {

--- a/test/browser/fixtures/issue-89.js
+++ b/test/browser/fixtures/issue-89.js
@@ -1,5 +1,4 @@
 'use strict';
-let Cycle = require('@cycle/core');
 let CycleDOM = require('../../../src');
 let Rx = require('rx');
 let {h} = CycleDOM;

--- a/test/browser/isolation.js
+++ b/test/browser/isolation.js
@@ -1,7 +1,7 @@
 'use strict';
 /* global describe, it, beforeEach */
 let assert = require('assert');
-let Cycle = require('@cycle/core');
+let Cycle = require('@cycle/rx-run').default;
 let CycleDOM = require('../../src');
 let Rx = require('rx');
 let {h, svg, div, p, span, h2, h3, h4, hJSX, select, option, makeDOMDriver} = CycleDOM;
@@ -31,10 +31,12 @@ describe('isolateSource', function () {
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
     const isolatedDOMSource = sources.DOM.isolateSource(sources.DOM, 'foo');
+
+    const dispose = run();
 
     // Make assertions
     isolatedDOMSource.select('.bar').observable.take(1).subscribe(elements => {
@@ -44,7 +46,7 @@ describe('isolateSource', function () {
       assert.notStrictEqual(typeof correctElement, 'undefined');
       assert.strictEqual(correctElement.tagName, 'H4');
       assert.strictEqual(correctElement.textContent, 'Correct');
-      sources.dispose();
+      dispose();
       done();
     });
   });
@@ -56,15 +58,17 @@ describe('isolateSource', function () {
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
+
+    const dispose = run();
 
     const isolatedDOMSource = sources.DOM.isolateSource(sources.DOM, 'top-most');
     // Make assertions
     assert.strictEqual(typeof isolatedDOMSource.isolateSource, 'function');
     assert.strictEqual(typeof isolatedDOMSource.isolateSink, 'function');
-    sources.dispose();
+    dispose();
     done();
   });
 });
@@ -78,9 +82,11 @@ describe('isolateSink', function () {
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
+
+    const dispose = run();
 
     // Make assertions
     sources.DOM.select(':root').observable.take(1)
@@ -90,7 +96,7 @@ describe('isolateSink', function () {
         assert.notStrictEqual(typeof element, 'undefined');
         assert.strictEqual(element.tagName, 'H3');
         assert.strictEqual(element.className, 'top-most cycle-scope-foo');
-        sources.dispose();
+        dispose();
         done();
       });
   });
@@ -103,9 +109,11 @@ describe('isolateSink', function () {
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
+
+    const dispose = run();
 
     // Make assertions
     sources.DOM.select(':root').observable.take(1)
@@ -115,7 +123,7 @@ describe('isolateSink', function () {
         assert.notStrictEqual(typeof element, 'undefined');
         assert.strictEqual(element.tagName, 'H3');
         assert.strictEqual(element.className, 'cycle-scope-foo');
-        sources.dispose();
+        dispose();
         done();
       });
   });
@@ -139,9 +147,11 @@ describe('isolateSink', function () {
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
+
+    const dispose = run();
 
     // Make assertions
     sources.DOM.select(':root').observable.skip(4).take(1)
@@ -151,7 +161,7 @@ describe('isolateSink', function () {
         assert.notStrictEqual(typeof element, 'undefined');
         assert.strictEqual(element.tagName, 'SPAN');
         assert.strictEqual(element.className, 'tab1 cycle-scope-1');
-        sources.dispose();
+        dispose();
         done();
       });
   });
@@ -174,9 +184,11 @@ describe('isolation', function () {
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
+
+    const dispose = run();
 
     sources.DOM.select('.bar').observable.take(1).subscribe(function (elements) {
       assert.strictEqual(Array.isArray(elements), true);
@@ -213,9 +225,11 @@ describe('isolation', function () {
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
+
+    const dispose = run();
 
     sinks.island.take(1).subscribe(function (elements) {
       assert.strictEqual(Array.isArray(elements), true);
@@ -264,9 +278,11 @@ describe('isolation', function () {
       };
     }
 
-    const {sources, sinks} = Cycle.run(Monalisa, {
+    const {sources, sinks, run} = Cycle(Monalisa, {
       DOM: makeDOMDriver(createRenderTarget())
     });
+
+    const dispose = run();
 
     const frameClick$ = sinks.frameClick.map(ev => ({
       type: ev.type,
@@ -291,7 +307,7 @@ describe('isolation', function () {
       ])
     ).subscribe(isEqual => {
       assert.strictEqual(isEqual, true);
-      sources.dispose();
+      dispose();
       done();
     });
 
@@ -337,9 +353,11 @@ describe('isolation', function () {
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
+
+    const dispose = run();
 
     const {isolateSource} = sources.DOM;
 
@@ -387,9 +405,11 @@ describe('isolation', function () {
      };
    }
 
-   const {sinks, sources} = Cycle.run(IsolatedApp, {
+   const {sinks, sources, run} = Cycle(IsolatedApp, {
      DOM: makeDOMDriver(createRenderTarget())
    });
+
+   const dispose = run();
 
    // Make assertions
    const selection = sinks.triangleElement.subscribe(elements => {

--- a/test/browser/render.js
+++ b/test/browser/render.js
@@ -1,7 +1,7 @@
 'use strict';
 /* global describe, it, beforeEach */
 let assert = require('assert');
-let Cycle = require('@cycle/core');
+let Cycle = require('@cycle/rx-run').default;
 let CycleDOM = require('../../src');
 let Fixture89 = require('./fixtures/issue-89');
 let Rx = require('rx');
@@ -30,16 +30,18 @@ describe('DOM Rendering', function () {
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
+
+    const dispose = run();
 
     sources.DOM.observable.subscribe(function (root) {
       const selectEl = root.querySelector('.my-class');
       assert.notStrictEqual(selectEl, null);
       assert.notStrictEqual(typeof selectEl, 'undefined');
       assert.strictEqual(selectEl.tagName, 'SELECT');
-      sources.dispose();
+      dispose();
       done();
     });
   });
@@ -58,16 +60,18 @@ describe('DOM Rendering', function () {
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
+
+    const dispose = run();
 
     sources.DOM.select(':root').observable.take(1).subscribe(function (root) {
       const selectEl = root.querySelector('.my-class');
       assert.notStrictEqual(selectEl, null);
       assert.notStrictEqual(typeof selectEl, 'undefined');
       assert.strictEqual(selectEl.tagName, 'SELECT');
-      sources.dispose();
+      dispose();
       done();
     });
   });
@@ -89,9 +93,11 @@ describe('DOM Rendering', function () {
     }
 
     // Run it
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
+
+    const dispose = run();
 
     // Assert it
     sources.DOM.select(':root').observable.skip(1).take(1).subscribe(function (root) {
@@ -100,7 +106,7 @@ describe('DOM Rendering', function () {
       assert.notStrictEqual(typeof selectEl, 'undefined');
       assert.strictEqual(selectEl.tagName, 'H4');
       assert.strictEqual(selectEl.textContent, 'Constantly hello0');
-      sources.dispose();
+      dispose();
       done();
     });
   });
@@ -113,9 +119,11 @@ describe('DOM Rendering', function () {
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
+
+    const dispose = run();
 
     sources.DOM.select('.myelementclass').observable.first() // 1st
       .subscribe(function (elements) {
@@ -130,7 +138,7 @@ describe('DOM Rendering', function () {
         assert.notStrictEqual(myelement, null);
         assert.strictEqual(myelement.tagName, 'H3');
         assert.strictEqual(myelement.textContent, '456');
-        sources.dispose();
+        dispose();
         done();
       });
   });
@@ -143,9 +151,11 @@ describe('DOM Rendering', function () {
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
+
+    const dispose = run();
 
     sources.DOM.select('.myelementclass').observable.first() // 1st
       .subscribe(function (elements) {
@@ -160,7 +170,7 @@ describe('DOM Rendering', function () {
         assert.notStrictEqual(myelement, null);
         assert.strictEqual(myelement.tagName, 'H3');
         assert.strictEqual(myelement.textContent, '456');
-        sources.dispose();
+        dispose();
         done();
       });
   });
@@ -178,9 +188,11 @@ describe('DOM Rendering', function () {
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
+
+    const dispose = run();
 
     sources.DOM.select(':root').observable.take(1).subscribe(function (root) {
       const selectEl = root.querySelector('.child');
@@ -188,7 +200,7 @@ describe('DOM Rendering', function () {
       assert.notStrictEqual(typeof selectEl, 'undefined');
       assert.strictEqual(selectEl.tagName, 'H4');
       assert.strictEqual(selectEl.textContent, 'I am a kid');
-      sources.dispose();
+      dispose();
       done();
     });
   });
@@ -214,9 +226,11 @@ describe('DOM Rendering', function () {
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
+
+    const dispose = run();
 
     sources.DOM.select(':root').observable.take(1).subscribe(function (root) {
       const selectEl = root.querySelector('.grandchild');
@@ -224,7 +238,7 @@ describe('DOM Rendering', function () {
       assert.notStrictEqual(typeof selectEl, 'undefined');
       assert.strictEqual(selectEl.tagName, 'H4');
       assert.strictEqual(selectEl.textContent, 'I am a baby');
-      sources.dispose();
+      dispose();
       done();
     });
   });
@@ -242,16 +256,18 @@ describe('DOM Rendering', function () {
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
+
+    const dispose = run();
 
     sources.DOM.select(':root').observable.take(1).subscribe(function (root) {
       const selectEl = root.querySelector('.child');
       assert.notStrictEqual(selectEl, null);
       assert.notStrictEqual(typeof selectEl, 'undefined');
       assert.strictEqual(selectEl.tagName, 'g');
-      sources.dispose();
+      dispose();
       done();
     });
   });
@@ -269,7 +285,7 @@ describe('DOM Rendering', function () {
       };
     };
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
 
@@ -280,10 +296,10 @@ describe('DOM Rendering', function () {
       .sequenceEqual(expected)
       .subscribe((areSame) => {
         assert.strictEqual(areSame, true);
-        sources.dispose();
-        sinks.dispose();
         done();
       });
+
+    run();
   });
 
   it('should ignore `null` children values', function (done) {
@@ -296,15 +312,16 @@ describe('DOM Rendering', function () {
       };
     };
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
+
+    const dispose = run();
 
     sources.DOM.observable.subscribe(function(root){
       const myElement = root.querySelector('.test')
       assert.strictEqual(myElement.children.length, 1);
-      sources.dispose();
-      sinks.dispose();
+      dispose();
       done();
     });
   });
@@ -320,15 +337,16 @@ describe('DOM Rendering', function () {
       };
     };
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
+
+    const dispose = run();
 
     sources.DOM.observable.subscribe(function(root){
       const myElement = root.querySelector('.test')
       assert.strictEqual(myElement.children.length, 0);
-      sources.dispose();
-      sinks.dispose();
+      dispose();
       done();
     });
   });
@@ -345,15 +363,16 @@ describe('DOM Rendering', function () {
       };
     };
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
+
+    const dispose = run();
 
     sources.DOM.observable.subscribe(function(root){
       const myElement = root.querySelector('.test')
       assert.strictEqual(myElement.children.length, 2);
-      sources.dispose();
-      sinks.dispose();
+      dispose();
       done();
     });
   });

--- a/test/browser/select.js
+++ b/test/browser/select.js
@@ -1,7 +1,7 @@
 'use strict';
 /* global describe, it */
 let assert = require('assert');
-let Cycle = require('@cycle/core');
+let Cycle = require('@cycle/rx-run').default;
 let CycleDOM = require('../../src');
 let Fixture89 = require('./fixtures/issue-89');
 let Rx = require('rx');
@@ -30,9 +30,11 @@ describe('DOMSource.select()', function () {
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
+
+    const dispose = run();
 
     sources.DOM.select(':root').observable.take(1).subscribe(root => {
       const classNameRegex = /top\-most/;
@@ -40,7 +42,7 @@ describe('DOMSource.select()', function () {
       const child = root.children[0];
       assert.notStrictEqual(classNameRegex.exec(child.className), null);
       assert.strictEqual(classNameRegex.exec(child.className)[0], 'top-most');
-      sources.dispose();
+      dispose();
       done();
     });
   });
@@ -52,9 +54,11 @@ describe('DOMSource.select()', function () {
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
+
+    const dispose = run();
 
     // Make assertions
     const selection = sources.DOM.select('.myelementclass');
@@ -62,7 +66,7 @@ describe('DOMSource.select()', function () {
     assert.strictEqual(typeof selection.observable, 'object');
     assert.strictEqual(typeof selection.observable.subscribe, 'function');
     assert.strictEqual(typeof selection.events, 'function');
-    sources.dispose();
+    dispose();
     done();
   });
 
@@ -73,9 +77,11 @@ describe('DOMSource.select()', function () {
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
+
+    const dispose = run();
 
     // Make assertions
     sources.DOM.select('.myelementclass').observable.take(1)
@@ -88,7 +94,7 @@ describe('DOMSource.select()', function () {
         // Array with the H3 element
         assert.strictEqual(elements[0].tagName, 'H3');
         assert.strictEqual(elements[0].textContent, 'Foobar');
-        sources.dispose();
+        dispose();
         done();
       });
   });
@@ -107,9 +113,11 @@ describe('DOMSource.select()', function () {
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
+
+    const dispose = run();
 
     // Make assertions
     sources.DOM.select('.foo').select('.bar').observable.take(1)
@@ -120,7 +128,7 @@ describe('DOMSource.select()', function () {
         assert.notStrictEqual(typeof element, 'undefined');
         assert.strictEqual(element.tagName, 'H4');
         assert.strictEqual(element.textContent, 'Correct');
-        sources.dispose();
+        dispose();
         done();
       })
   });
@@ -141,9 +149,11 @@ describe('DOMSource.select()', function () {
       };
     }
 
-    const {sinks, sources} = Cycle.run(app, {
+    const {sinks, sources, run} = Cycle(app, {
       DOM: makeDOMDriver(createRenderTarget())
     });
+
+    const dispose = run();
 
     // Make assertions
     const selection = sources.DOM.select('.triangle').observable.take(1)
@@ -153,6 +163,7 @@ describe('DOMSource.select()', function () {
         assert.notStrictEqual(triangleElement, null);
         assert.notStrictEqual(typeof triangleElement, 'undefined');
         assert.strictEqual(triangleElement.tagName, 'polygon');
+        dispose();
         done();
       });
   });

--- a/test/node/html-render.js
+++ b/test/node/html-render.js
@@ -1,7 +1,7 @@
 'use strict';
 /* global describe, it, beforeEach */
 let assert = require('assert');
-let Cycle = require('@cycle/core');
+let Cycle = require('@cycle/rx-run').default;
 let CycleDOM = require('../../src');
 let Rx = require('rx');
 let {div, h3, h, makeHTMLDriver} = CycleDOM;
@@ -13,13 +13,15 @@ describe('HTML Driver', function () {
         html: Rx.Observable.just(div('.test-element', ['Foobar']))
       };
     }
-    let {sinks, sources} = Cycle.run(app, {
+    let {sinks, sources, run} = Cycle(app, {
       html: makeHTMLDriver()
     });
     sources.html.subscribe(html => {
       assert.strictEqual(html, '<div class="test-element">Foobar</div>');
       done();
     });
+
+    run();
   });
 
   it('should make bogus select().events() as sources', function (done) {
@@ -31,13 +33,15 @@ describe('HTML Driver', function () {
         html: Rx.Observable.just(div('.test-element', ['Foobar']))
       };
     }
-    let {sinks, sources} = Cycle.run(app, {
+    let {sinks, sources, run} = Cycle(app, {
       html: makeHTMLDriver()
     });
     sources.html.subscribe(html => {
       assert.strictEqual(html, '<div class="test-element">Foobar</div>');
       done();
     });
+
+    run();
   });
 
   it('should output simple HTML Observable', function (done) {
@@ -46,13 +50,15 @@ describe('HTML Driver', function () {
         html: Rx.Observable.just(div('.test-element', ['Foobar']))
       };
     }
-    let {sinks, sources} = Cycle.run(app, {
+    let {sinks, sources, run} = Cycle(app, {
       html: makeHTMLDriver()
     });
     sources.html.subscribe(html => {
       assert.strictEqual(html, '<div class="test-element">Foobar</div>');
       done();
     });
+
+    run();
   });
 
   it('should render a simple nested vtree$ as HTML', function (done) {
@@ -63,7 +69,7 @@ describe('HTML Driver', function () {
         ]))
       };
     }
-    let {sinks, sources} = Cycle.run(app, {
+    let {sinks, sources, run} = Cycle(app, {
       DOM: makeHTMLDriver()
     });
     sources.DOM.subscribe(html => {
@@ -74,6 +80,8 @@ describe('HTML Driver', function () {
       );
       done();
     });
+
+    run();
   });
 
   it('should render double nested vtree$ as HTML', function (done) {
@@ -87,9 +95,9 @@ describe('HTML Driver', function () {
         ]))
       };
     }
-    let html$ = Cycle.run(app, { html: makeHTMLDriver() }).sources.html;
+    let {sources, run} = Cycle(app, { html: makeHTMLDriver() });
 
-    html$.subscribe(html => {
+    sources.html.subscribe(html => {
       assert.strictEqual(html,
         '<div class="test-element">' +
           '<div class="a-nice-element">' +
@@ -99,6 +107,7 @@ describe('HTML Driver', function () {
       );
       done();
     });
+    run();
   });
 
   it('should HTML-render a nested vtree$ with props', function (done) {
@@ -116,7 +125,7 @@ describe('HTML Driver', function () {
         )
       };
     }
-    let {sinks, sources} = Cycle.run(app, {
+    let {sinks, sources, run} = Cycle(app, {
       DOM: makeHTMLDriver()
     });
 
@@ -128,6 +137,8 @@ describe('HTML Driver', function () {
       );
       done();
     });
+
+    run();
   });
 
   it('should render a complex and nested vtree$ as HTML', function (done) {
@@ -151,7 +162,7 @@ describe('HTML Driver', function () {
         )
       };
     }
-    let {sinks, sources} = Cycle.run(app, {
+    let {sinks, sources, run} = Cycle(app, {
       html: makeHTMLDriver()
     });
 
@@ -174,5 +185,6 @@ describe('HTML Driver', function () {
       );
       done();
     });
+    run();
   });
 });


### PR DESCRIPTION
Dev depend on @cycle/rx-run instead of @cycle/core
and adjust the tests to work with @cycle/rx-run's slightly different usage.

Will merge when the next version of Cycle is ready 
