### PR TITLE
Fixing makeVNodeWrapper case sensitivity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ node_modules
 npm-debug.log
 
 test/browser/page/*.js
+test/bundle.js
 lib/

--- a/src/makeDOMDriver.js
+++ b/src/makeDOMDriver.js
@@ -19,9 +19,9 @@ function makeVNodeWrapper(rootElement) {
     const {id: vNodeId = selectorId} = vNodeDataProps
 
     const isVNodeAndRootElementIdentical =
-      vNodeId === rootElement.id &&
-      selectorTagName === rootElement.tagName &&
-      vNodeClassName === rootElement.className
+      vNodeId.toUpperCase() === rootElement.id.toUpperCase() &&
+      selectorTagName.toUpperCase() === rootElement.tagName.toUpperCase() &&
+      vNodeClassName.toUpperCase() === rootElement.className.toUpperCase()
 
     if (isVNodeAndRootElementIdentical) {
       return vNode

--- a/test/browser/render.js
+++ b/test/browser/render.js
@@ -357,4 +357,28 @@ describe('DOM Rendering', function () {
       done();
     });
   });
+
+  it('should not wrap root vNode if it matches the render target', function (done) {
+    function app(){
+      return {
+        DOM: Rx.Observable.just(h('div.cycletest', {}, [
+          h('h4', {}, 'Hello'),
+        ]))
+      };
+    };
+
+    const {sinks, sources} = Cycle.run(app, {
+      DOM: makeDOMDriver(createRenderTarget())
+    });
+
+    sources.DOM.observable.subscribe(function(root){
+      const myElement = root;
+      assert.strictEqual(myElement.children.length, 1);
+      const myFirstChild = myElement.children[0];
+      assert.strictEqual(myFirstChild.children.length, 0);
+      sources.dispose();
+      sinks.dispose();
+      done();
+    });
+  });
 });


### PR DESCRIPTION
I discovered that cycle-snabbdom wasn't patching over the render target anymore.

`selectorTagName === rootElement.tagName` was evaluating false.  One was `div`, the other was `DIV`.

Added test which ensures the root vNode doesn't get wrapped (by checking child counts) if it matches the render target selector.

Made the _is this identical_ logic all uppercase for id, tagname, and class.  I don't see any reason case should matter for id or class.

Test passed after implementing the changes.  Worked properly in my example app also.
