### PR TITLE
fix(events): fix for setting automatically setting useCapture

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -18,6 +18,24 @@ const eventTypesThatDontBubble = [
   `submit`,
   `change`,
   `reset`,
+  `timeupdate`,
+  `playing`,
+  `waiting`,
+  `seeking`,
+  `seeked`,
+  `ended`,
+  `loadedmetadata`,
+  `loadeddata`,
+  `canplay`,
+  `canplaythrough`,
+  `durationchange`,
+  `play`,
+  `pause`,
+  `ratechange`,
+  `volumechange`,
+  `suspend`,
+  `emptied`,
+  `stalled`,
 ]
 
 function maybeMutateEventPropagationAttributes(event) {
@@ -67,12 +85,8 @@ function makeSimulateBubbling(namespace, rootEl) {
   }
 }
 
-const defaults = {
-  useCapture: false,
-}
-
 function makeEventsSelector(rootElement$, namespace) {
-  return function eventsSelector(type, options = defaults) {
+  return function eventsSelector(type, options) {
     if (typeof type !== `string`) {
       throw new Error(`DOM driver's events() expects argument to be a ` +
         `string representing the event type to listen for.`)

--- a/src/events.js
+++ b/src/events.js
@@ -86,7 +86,7 @@ function makeSimulateBubbling(namespace, rootEl) {
 }
 
 function makeEventsSelector(rootElement$, namespace) {
-  return function eventsSelector(type, options) {
+  return function eventsSelector(type, options = {}) {
     if (typeof type !== `string`) {
       throw new Error(`DOM driver's events() expects argument to be a ` +
         `string representing the event type to listen for.`)

--- a/test/browser/render.js
+++ b/test/browser/render.js
@@ -273,13 +273,11 @@ describe('DOM Rendering', function () {
       DOM: makeDOMDriver(createRenderTarget())
     });
 
-    const expected = Rx.Observable.from(['1/1','2/1','2/2'])
-
     sources.DOM.select('.target').observable
       .map(els => els[0].innerHTML)
-      .sequenceEqual(expected)
-      .subscribe((areSame) => {
-        assert.strictEqual(areSame, true);
+      .last()
+      .subscribe((html) => {
+        assert.strictEqual(html, '2/2');
         sources.dispose();
         sinks.dispose();
         done();


### PR DESCRIPTION
Fixes listening to non-bubbling events by default. Previously useCapture was
defaulted to false via the `default` values and would automatically set useCapture to
false if a user did not manually define it.

Closes #21 
